### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
Potential fix for [https://github.com/JosunLP/checkai/security/code-scanning/5](https://github.com/JosunLP/checkai/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal privileges required. For this CI workflow, the jobs only need to read repository contents to check out the code; they do not create releases, modify contents, or interact with issues/PRs. Therefore, `contents: read` at the workflow level is an appropriate minimal setting.

The best way to fix this without changing functionality is to add a single `permissions` block near the top of `.github/workflows/ci.yml` at the workflow root level, right after the `on:` section and before `env:`. This block will apply to all jobs (`fmt`, `clippy`, `test`, and `build`), including the highlighted `build` job. No other YAML sections, steps, or actions need to be changed, and no imports or additional definitions are required, since `permissions` is a native GitHub Actions workflow key.

Concretely, in `.github/workflows/ci.yml`, insert:
```yaml
permissions:
  contents: read
```
after the `on:` block (after line 7 in the provided snippet). This leaves the jobs and steps untouched while ensuring the `GITHUB_TOKEN` is limited to read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
