### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JosunLP/checkai/security/code-scanning/3](https://github.com/JosunLP/checkai/security/code-scanning/3)

In general, this issue is fixed by explicitly specifying `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or per job, and setting them as restrictive as possible (typically `contents: read` for basic CI that only needs to check out code). This documents the intended permissions and prevents unintended elevation if repository defaults are broader.

For this workflow, all jobs (`fmt`, `clippy`, `test`, `build`) simply check out the repository and run Rust tooling; none needs to write to the repository, issues, or pull requests. The single best fix without changing functionality is to add a workflow-level `permissions` block right after the `name: CI` line, setting `contents: read`. This will apply to all jobs uniformly and satisfy CodeQL’s requirement while maintaining current behavior on any repo whose defaults are at least as permissive. No additional imports or methods are required, only this YAML addition in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
