### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JosunLP/checkai/security/code-scanning/2](https://github.com/JosunLP/checkai/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow (or each job) that grants only the minimal `GITHUB_TOKEN` scopes required. For this CI workflow that only checks out code and runs Rust tooling, read-only access to repository contents is sufficient, so `contents: read` is an appropriate minimal setting. Adding it at the top level under the workflow name (or after `on:`) will apply to all jobs that don’t override `permissions`.

The single best fix here, without changing existing functionality, is to add a root-level `permissions` block with `contents: read`. No job appears to need to write to issues, pull requests, or releases. This should be inserted after the `name: CI` (line 1) and before the `on:` block (line 3) or immediately after `on:`; both are valid, but placing it right after the name keeps the file clear and conventional. No additional methods, imports, or other definitions are needed, since this is purely a YAML configuration change within `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
