### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/JosunLP/checkai/security/code-scanning/1](https://github.com/JosunLP/checkai/security/code-scanning/1)

In general, this should be fixed by explicitly adding a `permissions` block that restricts the `GITHUB_TOKEN` to the minimum required scopes. For a workflow that just checks out code and runs `cargo build` and `cargo test`, read-only access to repository contents is sufficient.

The best fix without changing existing functionality is to add a root-level `permissions` block (right under the `name` or `on` section) that applies to all jobs. We can set `contents: read`, which is enough for `actions/checkout` to fetch the code. No steps in this workflow require write access to repository contents, issues, pull requests, or packages, so we don’t need any write scopes. Concretely, in `.github/workflows/rust.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (for example, after the `on:` block). No imports or additional methods are needed; this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
